### PR TITLE
[CPU][sgl-kernel] extend_attention_cpu: fix nan for large seq

### DIFF
--- a/sgl-kernel/csrc/cpu/extend.cpp
+++ b/sgl-kernel/csrc/cpu/extend.cpp
@@ -207,6 +207,14 @@ void extend_attention_kernel_impl(
         if (num_keys - n <= BLOCK_N) {
           for (int row = 0; row < m_size; ++row) {
             int last_col = m + row - n;
+            // Clamp to -1: when n > m + row every key in this block is a future
+            // key, so the entire row should be masked.  Without this clamp,
+            // last_col+1 <= 0 and fill_stub would write before row_ptr.
+            // Example: 
+            //  For max_len_extend > 4096 → selects BLOCK_M=512, BLOCK_N=768
+            //  m + BLOCK_M = 512 + 512 = 1024 > BLOCK_N = 768, this means we can have a a second n-block at n=768.
+            //  For m = 512, row = 0, n = 768, last_col = 512 + 0 - 768 = -256 → out of bounds write in fill_stub
+            last_col = std::max(last_col, -1);            
             // fill [last_col + 1, n_size) to -inf
             float* row_ptr = s_i + row * BLOCK_N;
             fill_stub(row_ptr + last_col + 1, -std::numeric_limits<float>::infinity(), n_size - last_col - 1);

--- a/sgl-kernel/csrc/cpu/extend.cpp
+++ b/sgl-kernel/csrc/cpu/extend.cpp
@@ -204,10 +204,10 @@ void extend_attention_kernel_impl(
             /* C     */ s_i);
 
         // apply causal mask
-        // Mask any block whose last key (n + n_size - 1) is strictly after the first query position (m), i.e. n + n_size - 1 > m.
-        // The original condition was `num_keys - n <= BLOCK_N` (last n-block only).
-        // That was correct when BLOCK_M <= BLOCK_N/2 because earlier n-blocks were
-        // guaranteed to contain only past keys.  With BLOCK_M=512, BLOCK_N=768:
+        // Mask any block whose last key (n + n_size - 1) is strictly after the first query position (m), i.e. n +
+        // n_size - 1 > m. The original condition was `num_keys - n <= BLOCK_N` (last n-block only). That was correct
+        // when BLOCK_M <= BLOCK_N/2 because earlier n-blocks were guaranteed to contain only past keys.  With
+        // BLOCK_M=512, BLOCK_N=768:
         //   BLOCK_M > BLOCK_N/2, so the first n-block can contain future keys.
         //   Example: m=512 (mb=1), num_keys=1024, first n-block covers keys [0, 768).
         //   Query row=0 is at position 512, so keys 513..767 are future and must be
@@ -219,11 +219,11 @@ void extend_attention_kernel_impl(
             // Clamp to -1: when n > m + row every key in this block is a future
             // key, so the entire row should be masked.  Without this clamp,
             // last_col+1 <= 0 and fill_stub would write before row_ptr.
-            // Example: 
+            // Example:
             //  For max_len_extend > 4096 → selects BLOCK_M=512, BLOCK_N=768
             //  m + BLOCK_M = 512 + 512 = 1024 > BLOCK_N = 768, this means we can have a a second n-block at n=768.
             //  For m = 512, row = 0, n = 768, last_col = 512 + 0 - 768 = -256 → out of bounds write in fill_stub
-            last_col = std::max(last_col, -1);            
+            last_col = std::max(last_col, -1);
             // fill [last_col + 1, n_size) to -inf
             float* row_ptr = s_i + row * BLOCK_N;
             fill_stub(row_ptr + last_col + 1, -std::numeric_limits<float>::infinity(), n_size - last_col - 1);

--- a/sgl-kernel/csrc/cpu/extend.cpp
+++ b/sgl-kernel/csrc/cpu/extend.cpp
@@ -204,7 +204,16 @@ void extend_attention_kernel_impl(
             /* C     */ s_i);
 
         // apply causal mask
-        if (num_keys - n <= BLOCK_N) {
+        // Mask any block whose last key (n + n_size - 1) is strictly after the first query position (m), i.e. n + n_size - 1 > m.
+        // The original condition was `num_keys - n <= BLOCK_N` (last n-block only).
+        // That was correct when BLOCK_M <= BLOCK_N/2 because earlier n-blocks were
+        // guaranteed to contain only past keys.  With BLOCK_M=512, BLOCK_N=768:
+        //   BLOCK_M > BLOCK_N/2, so the first n-block can contain future keys.
+        //   Example: m=512 (mb=1), num_keys=1024, first n-block covers keys [0, 768).
+        //   Query row=0 is at position 512, so keys 513..767 are future and must be
+        //   masked — but `num_keys - 0 = 1024 > BLOCK_N` skips masking entirely,
+        //   producing wrong (non-causal) attention for rows 0..254 of this m-block.
+        if (n + n_size - 1 > m) {
           for (int row = 0; row < m_size; ++row) {
             int last_col = m + row - n;
             // Clamp to -1: when n > m + row every key in this block is a future

--- a/test/srt/cpu/test_extend.py
+++ b/test/srt/cpu/test_extend.py
@@ -178,12 +178,116 @@ class TestExtendAttention(CustomTestCase):
 
         torch.testing.assert_close(o_ref, o_extend, atol=1e-2, rtol=1e-2)
 
+    def _test_extend_attention_fixed_lens(
+        self, B, H_Q, H_KV, D, DV, seq_len_prefixes, seq_len_extends
+    ):
+        """Test with exact (non-random) prefix and extend lengths.
+
+        Used to deterministically reproduce bugs that only trigger at specific
+        sequence lengths (e.g., negative last_col in causal masking when
+        BLOCK_M=512 and a key-block starts after the query block: n > m).
+        """
+        dtype = torch.bfloat16
+
+        b_seq_len_prefix = torch.tensor(seq_len_prefixes, dtype=torch.int32)
+        b_seq_len_extend = torch.tensor(seq_len_extends, dtype=torch.int32)
+        b_seq_len = b_seq_len_prefix + b_seq_len_extend
+        max_len_in_batch = b_seq_len.max().item()
+
+        b_req_idx = torch.arange(B, dtype=torch.int32)
+        req_to_tokens = torch.empty((B, max_len_in_batch), dtype=torch.int32)
+        b_start_loc = torch.zeros((B,), dtype=torch.int32)
+        b_start_loc[1:] = torch.cumsum(b_seq_len[:-1], 0)
+        b_start_loc_extend = torch.zeros((B,), dtype=torch.int32)
+        b_start_loc_extend[1:] = torch.cumsum(b_seq_len_extend[:-1], 0)
+
+        for i in range(B):
+            req_to_tokens[i, : b_seq_len[i]] = torch.arange(
+                b_start_loc[i], b_start_loc[i] + b_seq_len[i]
+            )
+
+        total_token_num = b_seq_len.sum().item()
+        extend_token_num = b_seq_len_extend.sum().item()
+
+        k_buffer = torch.randn((total_token_num, H_KV, D), dtype=dtype)
+        v_buffer = torch.randn((total_token_num, H_KV, DV), dtype=dtype)
+        k_extend = torch.empty((extend_token_num, H_KV, D), dtype=dtype)
+        v_extend = torch.empty((extend_token_num, H_KV, DV), dtype=dtype)
+        q_extend = torch.empty((extend_token_num, H_Q, D), dtype=dtype)
+
+        for i in range(B):
+            ext_start_buf = b_start_loc[i] + b_seq_len_prefix[i]
+            ext_end_buf = b_start_loc[i] + b_seq_len[i]
+            ext_start = b_start_loc_extend[i]
+            ext_end = b_start_loc_extend[i] + b_seq_len_extend[i]
+            k_extend[ext_start:ext_end] = k_buffer[ext_start_buf:ext_end_buf]
+            v_extend[ext_start:ext_end] = v_buffer[ext_start_buf:ext_end_buf]
+            q_extend[ext_start:ext_end] = torch.randn(
+                (b_seq_len_extend[i], H_Q, D), dtype=dtype
+            )
+
+        max_len_extend = b_seq_len_extend.max().item()
+        sm_scale = 1.0 / (D**0.5)
+        logit_cap = 0.0
+        enable_gqa = H_Q != H_KV
+
+        b_req_idx = b_req_idx.to(torch.int64)
+        b_seq_len = b_seq_len.to(torch.int64)
+
+        o_ref = torch.empty((extend_token_num, H_Q, DV), dtype=dtype)
+        self._run_sdpa_forward_extend(
+            q_extend,
+            o_ref,
+            k_buffer,
+            v_buffer,
+            req_to_tokens,
+            b_req_idx,
+            b_seq_len,
+            b_seq_len_prefix,
+            b_seq_len_extend,
+            scaling=sm_scale,
+            enable_gqa=enable_gqa,
+            causal=True,
+        )
+
+        o_extend = torch.empty((extend_token_num, H_Q, DV), dtype=dtype)
+        torch.ops.sgl_kernel.extend_attention_cpu(
+            q_extend,
+            k_extend,
+            v_extend,
+            o_extend,
+            k_buffer,
+            v_buffer,
+            req_to_tokens,
+            b_req_idx,
+            b_seq_len,
+            b_seq_len_extend,
+            b_start_loc_extend,
+            max_len_extend,
+            sm_scale,
+            logit_cap,
+        )
+
+        torch.testing.assert_close(o_ref, o_extend, atol=1e-2, rtol=1e-2)
+
     def test_extend_attention(self):
         for is_mla in [True, False]:
             self._test_extend_attention_once(1, 123, 1, 1, 128, 96, is_mla)
             self._test_extend_attention_once(1, 123, 16, 1, 128, 96, is_mla)
             self._test_extend_attention_once(4, 1230, 16, 4, 128, 96, is_mla)
             self._test_extend_attention_once(1, 9000, 16, 1, 32, 32, is_mla)
+
+
+    def test_extend_attention_large_seq_causal_mask(self):
+        self._test_extend_attention_fixed_lens(
+            B=1,
+            H_Q=8,
+            H_KV=2,
+            D=64,
+            DV=64,
+            seq_len_prefixes=[0],
+            seq_len_extends=[5000],
+        )
 
 
 if __name__ == "__main__":

--- a/test/srt/cpu/test_extend.py
+++ b/test/srt/cpu/test_extend.py
@@ -277,7 +277,6 @@ class TestExtendAttention(CustomTestCase):
             self._test_extend_attention_once(4, 1230, 16, 4, 128, 96, is_mla)
             self._test_extend_attention_once(1, 9000, 16, 1, 32, 32, is_mla)
 
-
     def test_extend_attention_large_seq_causal_mask(self):
         self._test_extend_attention_fixed_lens(
             B=1,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Fixes nan for large input (> 4096) in the `extend_attention_cpu` kernel.

The error message raised when feeding a large input to model:
```sh
  File "/home/user/sglang/python/sglang/srt/layers/sampler.py", line 477, in top_k_top_p_min_p_sampling_from_probs_torch
    sampled_index = torch.multinomial(probs_sort, num_samples=1)
RuntimeError: probability tensor contains either `inf`, `nan` or element < 0
```
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
1. Fixes the case where `last_col` is negative
2. Fixes the condition to apply the causal mask

For input lens > 4096, `BLOCK_M = 512` and `BLOCK_N = 768` is selected. At `mb=1`, `m = mb * BLOCK_M = 512`, thus `num_keys = m + BLOCK_M = 1024`.
For the `n` loop, the valid n value is `n = 0` (`0<1024`) and `n = 768` (`768<1024`), so there's two n-blocks:
- first block: keys `[0, 767]` (size 768)
- second block: keys `[768, 1023]` (size 256)

The second block can be entirely future for early rows (e.g. row 0 at absolute query pos 512).
Before the fix, for the second block `[768, 1024]`, the `last_col` will be negative, the previous code will write before row_ptr, resulting in `nan`. This PR will set `last_col` to `-1` in this case and mask the entire row.
Before the fix, for the first block, `[513, 767]` need to be masked but the previous code only handles the last block `[768, 1023]`, making the result wrong. This PR will mask `[513, 767]` correctly.


<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

```sh
python -u test/srt/cpu/test_extend.py -k test_extend_attention_large_seq_causal_mask
```

Before the fix:
```sh
Mismatched elements: 281210 / 2560000 (11.0%)
Greatest absolute difference: nan at index (1601, 7, 0) (up to 0.01 allowed)
Greatest relative difference: nan at index (1536, 4, 0) (up to 0.01 allowed)
```

After the fix:
```sh
[CI Test Method] TestExtendAttention.test_extend_attention_large_seq_causal_mask
.
----------------------------------------------------------------------
Ran 1 test in 0.506s

OK
```


## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
4. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
5. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
6. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
